### PR TITLE
Added HTML reports for LightBDD

### DIFF
--- a/BDD/ConductOfCode/ConductOfCode/LightBDD/Stack_feature.Steps.cs
+++ b/BDD/ConductOfCode/ConductOfCode/LightBDD/Stack_feature.Steps.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using LightBDD;
 using NUnit.Framework;
+[assembly: Debuggable(true, true)] // to render steps properly when executed in Release mode
 
 namespace ConductOfCode.LightBDD
 {

--- a/BDD/ConductOfCode/ConductOfCode/app.config
+++ b/BDD/ConductOfCode/ConductOfCode/app.config
@@ -2,7 +2,15 @@
 <configuration>
   <configSections>
     <section name="specFlow" type="TechTalk.SpecFlow.Configuration.ConfigurationSectionHandler, TechTalk.SpecFlow" />
+    <section name="lightbdd" type="LightBDD.Configuration.LightBDDConfiguration, LightBDD"/>
   </configSections>
+  <lightbdd>
+    <summaryWriters>
+      <!-- FeaturesSummary.xml is added by default. Use <clear /> to remove it.-->
+      <clear/>
+      <add formatter="LightBDD.Results.Formatters.HtmlResultFormatter, LightBDD" output="Reports/FeaturesSummary.html"/>
+    </summaryWriters>
+  </lightbdd>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>


### PR DESCRIPTION
After test execution, the html report would be available in: `ConductOfCode\BDD\ConductOfCode\ConductOfCode\bin\Debug\Reports\`